### PR TITLE
update to latest rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,37 +2,38 @@
 name = "cargo-watch"
 version = "2.0.0"
 dependencies = [
- "docopt 0.6.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt_macros 0.6.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt_macros 0.6.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt"
-version = "0.6.23"
+version = "0.6.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt_macros"
-version = "0.6.23"
+version = "0.6.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "docopt 0.6.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "inotify"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -40,25 +41,25 @@ name = "notify"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "inotify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ keywords = [
 ]
 
 [dependencies]
+rustc-serialize = "*"
 docopt = "0.6"
 docopt_macros = "0.6"
 notify = "1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
-#![feature(macro_rules, phase, old_orphan_check)]
+#![feature(plugin)]
+#![allow(unstable)]
 #![warn(missing_docs)]
 //! Watch files in a Cargo project and compile it when they change
 
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate docopt;
-#[phase(plugin)] extern crate docopt_macros;
+#[plugin] #[no_link] extern crate docopt_macros;
 
 extern crate notify;
-#[phase(plugin, link)] extern crate log;
+#[plugin] #[macro_use] extern crate log;
 
 use notify::{Error, RecommendedWatcher, Watcher};
 use std::sync::mpsc::channel;

--- a/src/timelock.rs
+++ b/src/timelock.rs
@@ -3,7 +3,7 @@ extern crate time;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicInt, Ordering};
 
-pub fn current() -> int { time::get_time().sec as int }
-pub fn get(t: &Arc<AtomicInt>) -> int { t.load(Ordering::SeqCst) }
-pub fn new() -> Arc<AtomicInt> { Arc::new(AtomicInt::new(time::get_time().sec as int)) }
-pub fn update(t: &Arc<AtomicInt>) { t.store(time::get_time().sec as int, Ordering::SeqCst); }
+pub fn current() -> isize { time::get_time().sec as isize }
+pub fn get(t: &Arc<AtomicInt>) -> isize { t.load(Ordering::SeqCst) }
+pub fn new() -> Arc<AtomicInt> { Arc::new(AtomicInt::new(time::get_time().sec as isize)) }
+pub fn update(t: &Arc<AtomicInt>) { t.store(time::get_time().sec as isize, Ordering::SeqCst); }


### PR DESCRIPTION
* dependencies updated
* rustc-serialize is an external crate now
* plugin-related attributes updated (`#[plugin]`, `#[macro_use]`, etc)
* `int` renamed to `isize`
* rsnotify also updated (PR passcod/rsnotify#3)