### PR TITLE
feat(cmds): #11 support running any cargo cmd(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-watch"
-version = "2.1.5"
+version = "3.0.0"
 dependencies = [
  "docopt 0.6.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-watch"
-version = "2.1.5"
+version = "3.0.0"
 authors = [
   "Félix Saparelli <me@passcod.name>",
   "Antti Keränen <detegr@gmail.com>",
@@ -8,6 +8,7 @@ authors = [
   "Jonathan Neuschäfer <j.neuschaefer@gmx.net>",
   "Gabor Nagy <mail@aigeruth.hu>",
   "Ivan Jager <aij+git@mrph.org>",
+  "Christopher Brickley <brickley@gmail.com>",
 ]
 
 description = "Utility for cargo to compile projects when sources change"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 It will watch your `src` folder and any subdirectories for file changes,
 additions, removals, and moves (in or out), and run both `$ cargo build` and
 `$ cargo test` on your project.  You can also specify other things to be run,
-e.g. `$ cargo doc` and `$ cargo bench`, by passing flags.
+e.g. `$ cargo doc` and `$ cargo bench`, by passing `$ cargo watch doc bench`
+or more sophisticated cargo commands such as `$ cargo watch "build --release"
+"test test_"` which will send those two commands to cargo.
 See `$ cargo watch --help` for more.
 
 Just like any Cargo command, you can run it from any subdirectory in your

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -42,15 +42,16 @@ pub fn root() -> Option<PathBuf> {
   None
 }
 
-/// Runs a cargo command and displays the output.
-pub fn run(cmd: &str) {
-  println!("\n$ cargo {}", cmd);
+/// Runs one or more cargo commands and displays the output.
+pub fn run(cmds: &str) {
+  let cmds_vec: Vec<&str> = cmds.split_whitespace().collect();
+  println!("\n$ cargo {}", cmds);
   match Command::new("cargo")
     .stderr(Stdio::inherit())
     .stdout(Stdio::inherit())
-    .arg(cmd)
+    .args(&cmds_vec)
     .output() {
     Ok(o) => println!("-> {}", o.status),
-    Err(e) => println!("Failed to execute 'cargo {}': {}", cmd, e)
+    Err(e) => println!("Failed to execute 'cargo {}': {}", cmds, e)
   };
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -3,21 +3,17 @@ use std::sync::atomic::AtomicIsize;
 use std::thread;
 use super::{Config, cargo, ignore, notify, timelock};
 
-macro_rules! run_if_set(
-  ($flag:ident) => {
-    if $flag { cargo::run(stringify!($flag)) }
-  }
-);
-
 fn compile(t: Arc<AtomicIsize>, c: Arc<Config>) {
   let Config {
-    build, doc, test, bench
+    ref args
   } = *c;
   debug!("Starting a compile");
-  run_if_set!(build);
-  run_if_set!(doc);
-  run_if_set!(test);
-  run_if_set!(bench);
+  if args.len() > 0 {
+      args.iter().map(|v| cargo::run(v)).last();
+  }
+  else {
+      vec![String::from("build"), String::from("test")].iter().map(|v| cargo::run(v)).last();
+  }
   timelock::update(&t);
   debug!("Compile done");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,55 +21,37 @@ mod timelock;
 static USAGE: &'static str = "
 Usage: cargo-watch [watch] [options]
        cargo watch [options]
+       cargo-watch [watch] [<args>...]
+       cargo watch [<args>...]
 
 Options:
   -h, --help      Display this message
-  -b, --build     Run `cargo build` when a file is modified
-  -d, --doc       Run `cargo doc` when a file is modified
-  -t, --test      Run `cargo test` when a file is modified
-  -n, --bench     Run `cargo bench` when a file is modified
 
-Default options are `build` and `test`
+`cargo watch` can take one or more arguments to pass to cargo. For example,
+`cargo watch \"test ex_ --release\"` will run `cargo test ex_ --release`
+
+If no arguments are provided, then cargo will run `build` and `test`
 ";
 
 #[derive(RustcDecodable, Debug)]
 struct Args {
-    flag_build: bool,
-    flag_doc: bool,
-    flag_test: bool,
-    flag_bench: bool,
+    arg_args: Vec<String>,
 }
 
-#[derive(Clone,Copy)]
+#[derive(Clone)]
 pub struct Config {
-    build: bool,
-    doc: bool,
-    test: bool,
-    bench: bool
+    args: Vec<String>,
 }
 
 impl Config {
   fn new() -> Config {
     #![allow(unused_variables)]
     let Args {
-      flag_build: mut build,
-      flag_doc: doc,
-      flag_test: mut test,
-      flag_bench: bench,
+      arg_args: args,
     } = Docopt::new(USAGE).and_then(|d| d.decode()).unwrap_or_else(|e| e.exit());
 
-    if !build && !doc &&
-      !test && !bench {
-        // Default to build & doc
-        build = true;
-        test = true;
-      }
-
     Config {
-      build: build,
-      doc: doc,
-      test: test,
-      bench: bench
+      args: args,
     }
   }
 }


### PR DESCRIPTION
Add support for running arbitrary cargo commands.
For example:

```bash
cargo watch "test ex_ —release"
```

will run `cargo test ex_ —release`.

Also supports multiple arguments:

```bash
cargo watch build test
```

will run `cargo build` followed by `cargo test`.

I've been using this for the last few days and haven't run into any issues.

Let me know any changes and I'll incorporate.