### PR TITLE
When starting, do a command run before any file changes

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -40,6 +40,21 @@ pub fn handle(rx: Receiver<notify::Event>, mut commands: Vec<String>) {
     let mut kill: Option<Sender<()>> = None;
     let mut thread: Option<JoinHandle<()>> = None;
 
+    // At the start, run the command. cf. issue #37
+    info!("First run, so starting a command run");
+    // Create channel to send kill signals
+    let (tx2, rx2) = channel();
+    kill = Some(tx2);
+
+    let thread_commands = commands.clone();
+    let thread_job_info = job_info.clone();
+
+    thread = Some(
+        thread::spawn(move || {
+            execute_commands(&thread_commands, thread_job_info, rx2)
+        })
+    );
+
     // Handle events as long as the watcher still sends events
     // through the channel
     while let Ok(event) = rx.recv() {


### PR DESCRIPTION
I've often started cargo watch when started working on a project, and
it clearly doesn't do anything until a file has changed. Sometimes I
can't remember if all the tests passed (or if the code compiles), and
I'd like to see the output of cargo test. So I need to make a simple
change to something so that it'll run and I can see. But if cargo watch
ran the command as soon as it was started, this would be easier.

fixes #37