### PR TITLE
Remove unused import of notify::Error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ extern crate rustc_serialize;
 extern crate wait_timeout;
 
 use docopt::Docopt;
-use notify::{Error, RecommendedWatcher, Watcher};
+use notify::{RecommendedWatcher, Watcher};
 use std::sync::mpsc::channel;
 
 mod cargo;


### PR DESCRIPTION
Fixes the following warning when compiling or installing via cargo:

> src/main.rs:17:14: 17:19 warning: unused import, #[warn(unused_imports)] on by default
> src/main.rs:17 use notify::{Error, RecommendedWatcher, Watcher};
