### PR TITLE
Parse args before calling change_dir()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,11 +167,11 @@ fn get_options(debug: bool, matches: &ArgMatches) -> Args {
 }
 
 fn main() {
+    let matches = args::parse();
+
     change_dir();
 
-    let matches = args::parse();
     let debug = matches.is_present("debug");
-
     let opts = get_options(debug, &matches);
     watchexec::run(opts)
 }


### PR DESCRIPTION
Currently, calling `cargo watch -h` while not in a project causes the program to exit with the message "error: Not a Cargo project, aborting."

There are times when I want to see the help message while not being in a cargo project, so this PR moves the directory checking after the argument parsing.