### PR TITLE
Enhance the default ignores to fully cover vim and Emacs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,8 @@ fn get_ignores(debug: bool, matches: &ArgMatches) -> (bool, Vec<String>) {
     opts.push(format!("*{}.DS_Store", MAIN_SEPARATOR));
     opts.push("*.sw?".into());
     opts.push("*.sw?x".into());
+    opts.push("#*#".into());
+    opts.push(".#*".into());
 
     opts.push(format!("*{s}.hg{s}**", s = MAIN_SEPARATOR));
     opts.push(format!("*{s}.git{s}**", s = MAIN_SEPARATOR));

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,8 @@ fn get_ignores(debug: bool, matches: &ArgMatches) -> (bool, Vec<String>) {
     }
 
     opts.push(format!("*{}.DS_Store", MAIN_SEPARATOR));
-    opts.push("*.swp".into());
+    opts.push("*.sw?".into());
+    opts.push("*.sw?x".into());
 
     opts.push(format!("*{s}.hg{s}**", s = MAIN_SEPARATOR));
     opts.push(format!("*{s}.git{s}**", s = MAIN_SEPARATOR));


### PR DESCRIPTION
The default ignored files list for cargo-watch is missing some that I added to watchexec. It would be nice to have them here too.