### PR TITLE
Integrate .ignore flag from watchexec

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -44,7 +44,7 @@ pub fn parse() -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("ignore-nothing")
                         .long("ignore-nothing")
-                        .help("Ignore nothing, not even target/, .git/, and .ignore"),
+                        .help("Ignore nothing, not even target/ and .git/"),
                 )
                 .arg(
                     Arg::with_name("no-gitignore")

--- a/src/args.rs
+++ b/src/args.rs
@@ -44,12 +44,17 @@ pub fn parse() -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("ignore-nothing")
                         .long("ignore-nothing")
-                        .help("Ignore nothing, not even target/ and .git/"),
+                        .help("Ignore nothing, not even target/, .git/, and .ignore"),
                 )
                 .arg(
                     Arg::with_name("no-gitignore")
                         .long("no-gitignore")
                         .help("Don’t use .gitignore files"),
+                )
+                .arg(
+                    Arg::with_name("no-ignore")
+                        .long("no-ignore")
+                        .help("Don’t use .ignore files"),
                 )
                 .arg(
                     Arg::with_name("no-restart")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub fn set_ignores(debug: bool, builder: &mut ArgsBuilder, matches: &ArgMatches)
         }
 
         builder.no_vcs_ignore(true);
+        builder.no_ignore(true);
         return;
     }
 
@@ -71,6 +72,12 @@ pub fn set_ignores(debug: bool, builder: &mut ArgsBuilder, matches: &ArgMatches)
     builder.no_vcs_ignore(novcs);
     if debug {
         println!(">>> Load Git/VCS ignores: {:?}", !novcs);
+    }
+
+    let noignore = matches.is_present("no-ignore");
+    builder.no_ignore(noignore);
+    if debug {
+        println!(">>> Load .ignore ignores: {:?}", !noignore);
     }
 
     let mut list = vec![


### PR DESCRIPTION
ref. https://github.com/passcod/cargo-watch/issues/127

This seems to be all that's needed to provide a bit of flexibility on `cargo-watch` to use some of the flags upstream at `watchexec` (as of https://github.com/watchexec/watchexec/pull/127). 

Testing locally seems fine. The `.ignore` file already works as of the version bump so this isn't adding much that isn't already there.

Hope this looks alright! Let me know if I've missed anything.