### PR TITLE
Allow --features

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ $ cargo watch -x 'run -- --some-arg'
 
 # Run an arbitrary command
 $ cargo watch -s 'echo Hello world'
+
+# Run with features passed to cargo
+$ cargo watch --features "feature1,feature2"
 ```
 
 There's a lot more you can do! Here's a copy of the help:
@@ -85,6 +88,7 @@ OPTIONS:
     -x, --exec <cmd>...         Cargo command(s) to execute on changes [default: check]
     -s, --shell <cmd>...        Shell command(s) to execute on changes
     -d, --delay <delay>         File updates debounce delay in seconds [default: 0.5]
+        --features <features>   Space-separated list of features passed to cargo invocations
     -i, --ignore <pattern>...   Ignore a glob/gitignore-style pattern
     -w, --watch <watch>...      Watch specific file(s) or folder(s) [default: .]
 
@@ -301,6 +305,16 @@ program instead of cargo:
 ```
 $ cargo watch -x 'test -- --color=always'
 ```
+
+### I want to compile my build with additional features
+
+The `--features` flag is recognized and passed to all cargo invocations.
+
+```
+$ cargo watch --features feature1,feature2
+```
+
+will run `cargo check --features feature1,feature2` on every watched change.
 
 ### Something not covered above / I have a feature request
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ cargo watch -x 'run -- --some-arg'
 $ cargo watch -s 'echo Hello world'
 
 # Run with features passed to cargo
-$ cargo watch --features "feature1,feature2"
+$ cargo watch --features "foo,bar"
 ```
 
 There's a lot more you can do! Here's a copy of the help:

--- a/README.md
+++ b/README.md
@@ -311,10 +311,15 @@ $ cargo watch -x 'test -- --color=always'
 The `--features` flag is recognized and passed to all cargo invocations.
 
 ```
-$ cargo watch --features feature1,feature2
+$ cargo watch --features foo,bar
 ```
 
-will run `cargo check --features feature1,feature2` on every watched change.
+will run `cargo check --features foo,bar` on every watched change.
+The `--features` will be passed to every supported `cargo` subcommand,
+```
+$ cargo watch -x "b" -x "doc" --features foo,bar
+```
+will run both `build` and `doc` with the `foo` and `bar` features.
 
 ### Something not covered above / I have a feature request
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ OPTIONS:
     -x, --exec <cmd>...         Cargo command(s) to execute on changes [default: check]
     -s, --shell <cmd>...        Shell command(s) to execute on changes
     -d, --delay <delay>         File updates debounce delay in seconds [default: 0.5]
-        --features <features>   Space-separated list of features passed to cargo invocations
+        --features <features>   List of features passed to cargo invocations
     -i, --ignore <pattern>...   Ignore a glob/gitignore-style pattern
     -w, --watch <watch>...      Watch specific file(s) or folder(s) [default: .]
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -84,6 +84,12 @@ pub fn parse() -> ArgMatches<'static> {
                         .help("Ignore events emitted while the commands run"),
                 )
                 .arg(
+                    Arg::with_name("features")
+                        .long("features")
+                        .takes_value(true)
+                        .help("Space-separated list of features passed to cargo invocations"),
+                )
+                .arg(
                     Arg::with_name("quiet")
                         .short("q")
                         .long("quiet")

--- a/src/args.rs
+++ b/src/args.rs
@@ -87,7 +87,7 @@ pub fn parse() -> ArgMatches<'static> {
                     Arg::with_name("features")
                         .long("features")
                         .takes_value(true)
-                        .help("Space-separated list of features passed to cargo invocations"),
+                        .help("List of features passed to cargo invocations"),
                 )
                 .arg(
                     Arg::with_name("quiet")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,22 @@ pub fn set_commands(debug: bool, builder: &mut ArgsBuilder, matches: &ArgMatches
     if matches.is_present("cmd:cargo") {
         for cargo in values_t!(matches, "cmd:cargo", String).unwrap_or_else(|e| e.exit()) {
             let mut cmd: String = "cargo ".into();
-            if let Some(features) = features.as_ref() {
-                cmd.push_str("--features");
-                cmd.push_str(features);
-                cmd.push(' ');
-            }
             cmd.push_str(&cargo);
+            if let Some(features) = features.as_ref() {
+                let cargo = cargo.trim_start();
+                // features are supported for the following
+                // (b)uild, bench, doc, (r)un, test, install
+                if cargo.starts_with("b")
+                    || cargo.starts_with("check")
+                    || cargo.starts_with("doc")
+                    || cargo.starts_with("r")
+                    || cargo.starts_with("test")
+                    || cargo.starts_with("install")
+                {
+                    cmd.push_str(" --features ");
+                    cmd.push_str(features);
+                }
+            }
             commands.push(cmd);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,16 +49,16 @@ pub fn set_commands(debug: bool, builder: &mut ArgsBuilder, matches: &ArgMatches
                     || cargo.starts_with("test")
                     || cargo.starts_with("install")
                 {
-                    // Split command into words
-                    let mut words = cargo.split(|c: char| c.is_whitespace());
-                    let subcommand = words.next().unwrap();
+                    // Split command into first word and the arguments
+                    let word_boundary = cargo
+                        .find(|c: char| c.is_whitespace())
+                        .unwrap_or(cargo.len());
+                    let (subcommand, args) = cargo.split_at(word_boundary);
                     cmd.push_str(subcommand);
                     cmd.push_str(" --features ");
                     cmd.push_str(features);
-                    for arg in words {
-                        cmd.push(' ');
-                        cmd.push_str(arg);
-                    }
+                    cmd.push(' ');
+                    cmd.push_str(args)
                 } else {
                     cmd.push_str(&cargo);
                 }


### PR DESCRIPTION
Captures `--features <features>` and passes this to all cargo invocations.

I intentionally left out `--no-default-features` and `--all-features` to prevent feature creep. I think the current choice is the most common one, and for more advanced usages the workaround mentioned in #151 could be utilised.

Fixes #151 